### PR TITLE
use slice with proper length (a multiple of a block size)

### DIFF
--- a/pkg/des/des.go
+++ b/pkg/des/des.go
@@ -226,7 +226,7 @@ func GenerateMac(currentKey []byte, plainText, action string) ([]byte, error) {
 	initialVector := make([]byte, desBlockLen)
 	leftCipher, _ := encryption.NewDesECB(leftKey)
 	for partNum := 0; partNum < repeatCnt; partNum++ {
-		macPart := plainTextBytes[partNum*desBlockLen : (partNum+1)*desBlockLen]
+		macPart := serializePlaintext[partNum*desBlockLen : (partNum+1)*desBlockLen]
 		for in := range initialVector {
 			initialVector[in] = initialVector[in] ^ macPart[in]
 		}


### PR DESCRIPTION
Built [fails](https://github.com/moov-io/dukpt/actions/runs/8111228063/job/22170087783?pr=16#step:5:143) because of the following error:
```
--- FAIL: TestService__GenerateMac (0.00s)
panic: runtime error: slice bounds out of range [:24] with capacity 17 [recovered]
        panic: runtime error: slice bounds out of range [:24] with capacity 17

goroutine 16 [running]:
testing.tRunner.func1.2({0x8afc200, 0xc00001cca8})
        /usr/local/go/src/testing/testing.go:1631 +0x24a
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1634 +0x377
panic({0x8afc200?, 0xc00001cca8?})
        /usr/local/go/src/runtime/panic.go:770 +0x132
github.com/moov-io/dukpt/pkg/des.GenerateMac({0xc0001d0ce0?, 0x20?, 0x14?}, {0x8a3f17e?, 0x11}, {0x8a3bc6e?, 0x7?})
        /Users/alovak/dev/moov/dukpt/pkg/des/des.go:229 +0x345
github.com/moov-io/dukpt/pkg/server.GenerateMac({{0x8a3ac8d, 0x3}, {0x0, 0x0}, {0x0, 0x0}, {0x8a405c6, 0x14}, {0xc00001f940, 0x20}, ...})
        /Users/alovak/dev/moov/dukpt/pkg/server/wrapper.go:115 +0x271
github.com/moov-io/dukpt/pkg/server.(*service).GenerateMac(0xc0001ce570?, {0xc00001f940, 0x20}, {0x8a3f17e, 0x11}, {0x8a3bc6e, 0x7}, {0x0, 0x0})
        /Users/alovak/dev/moov/dukpt/pkg/server/service.go:212 +0x325
github.com/moov-io/dukpt/pkg/server.TestService__GenerateMac(0xc0001d41a0)
        /Users/alovak/dev/moov/dukpt/pkg/server/service_test.go:175 +0x265
```

This PR fixes the issue.