### PR TITLE
chore: silence CodeQL weak-crypto alerts for DUKPT DES/3DES

### DIFF
--- a/encryption/des_ecb.go
+++ b/encryption/des_ecb.go
@@ -2,6 +2,7 @@ package encryption
 
 import (
 	"crypto/cipher"
+	// DES/3DES are required by ANSI X9.24 DUKPT; not for general-purpose crypto.
 	"crypto/des" //nolint:gosec
 	"errors"
 	"fmt"
@@ -26,6 +27,7 @@ func NewTripleDesECB(key []byte) (*DesECB, error) {
 		tripleDESKey = append(tripleDESKey, key...)
 	}
 
+	// codeql[go/weak-cryptographic-algorithm] DES/3DES required by ANSI X9.24 DUKPT
 	cp, err := des.NewTripleDESCipher(tripleDESKey) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("creating cipher: %w", err)
@@ -37,6 +39,7 @@ func NewTripleDesECB(key []byte) (*DesECB, error) {
 }
 
 func NewDesECB(key []byte) (*DesECB, error) {
+	// codeql[go/weak-cryptographic-algorithm] DES required by ANSI X9.24 DUKPT
 	cp, err := des.NewCipher(key) //nolint:gosec
 	if err != nil {
 		return nil, fmt.Errorf("creating cipher: %w", err)
@@ -53,6 +56,7 @@ func (a *DesECB) Encrypt(plainText []byte) ([]byte, error) {
 	}
 
 	cipherText := make([]byte, len(plainText))
+	// codeql[go/weak-cryptographic-algorithm] DES/3DES required by ANSI X9.24 DUKPT
 	a.cipherBlock.Encrypt(cipherText, plainText)
 	return cipherText, nil
 }
@@ -63,6 +67,7 @@ func (a *DesECB) Decrypt(cipherText []byte) ([]byte, error) {
 	}
 
 	plainText := make([]byte, len(cipherText))
+	// codeql[go/weak-cryptographic-algorithm] DES/3DES required by ANSI X9.24 DUKPT
 	a.cipherBlock.Decrypt(plainText, cipherText)
 	return plainText, nil
 }

--- a/pkg/des/des.go
+++ b/pkg/des/des.go
@@ -319,7 +319,9 @@ func EncryptData(currentKey, iv []byte, plainText, action string) ([]byte, error
 		iv = append(iv, make([]byte, desBlockLen-len(iv))...)
 	}
 
+	// codeql[go/weak-cryptographic-algorithm] TDEA/CBC required by ANSI X9.24-1 DUKPT
 	mode := cipher.NewCBCEncrypter(dataCipher.GetBlock(), iv)
+	// codeql[go/weak-cryptographic-algorithm] TDEA/CBC required by ANSI X9.24-1 DUKPT
 	mode.CryptBlocks(ciphertext, serializePlaintext)
 
 	return ciphertext, nil
@@ -391,7 +393,9 @@ func DecryptData(currentKey, ciphertext, iv []byte, action string) (string, erro
 		iv = iv[:desBlockLen]
 	}
 
+	// codeql[go/weak-cryptographic-algorithm] TDEA/CBC required by ANSI X9.24-1 DUKPT
 	mode := cipher.NewCBCDecrypter(dataCipher.GetBlock(), iv)
+	// codeql[go/weak-cryptographic-algorithm] TDEA/CBC required by ANSI X9.24-1 DUKPT
 	mode.CryptBlocks(plaintext, serializePlaintext)
 
 	return string(plaintext), nil

--- a/pkg/des/des_internal.go
+++ b/pkg/des/des_internal.go
@@ -57,6 +57,13 @@ func serializeKeyWithHexadecimal(key []byte) {
 
 // Non-reversible Key Generation Process
 func makeNonReversibleKey(ksnBytes, keyBytes []byte) ([]byte, error) {
+	if len(keyBytes) < keyLen {
+		return nil, fmt.Errorf("key register length must be at least %d bytes", keyLen)
+	}
+	if len(ksnBytes) < des.BlockSize {
+		return nil, fmt.Errorf("ksn length must be at least %d bytes", des.BlockSize)
+	}
+
 	var err error
 	cryptoReg1 := make([]byte, des.BlockSize)
 	cryptoReg2 := make([]byte, des.BlockSize)
@@ -64,13 +71,17 @@ func makeNonReversibleKey(ksnBytes, keyBytes []byte) ([]byte, error) {
 	// The 64 right-most bits of the Key Serial Number Register is transferred into Crypto Register-1
 	copy(cryptoReg1, ksnBytes[len(ksnBytes)-des.BlockSize:])
 
+	// Split the 16-byte key register so index math stays in bounds for static analysis.
+	leftKey := keyBytes[:des.BlockSize]
+	rightKey := keyBytes[des.BlockSize:keyLen]
+
 	// 1) Crypto Register-1 XORed with the right half of the Key Register goes to Crypto Register-2
 	for index := range cryptoReg2 {
-		cryptoReg2[index] = cryptoReg1[index] ^ keyBytes[index+8]
+		cryptoReg2[index] = cryptoReg1[index] ^ rightKey[index]
 	}
 
 	// 2) Crypto Register-2 DEA-encrypted using, as the key, the left half of the Key Register goes to Crypto Register-2
-	cipher1, _ := encryption.NewDesECB(keyBytes[:des.BlockSize])
+	cipher1, _ := encryption.NewDesECB(leftKey)
 	cryptoReg2, err = cipher1.Encrypt(cryptoReg2)
 	if err != nil {
 		return nil, err
@@ -78,21 +89,24 @@ func makeNonReversibleKey(ksnBytes, keyBytes []byte) ([]byte, error) {
 
 	// 3) Crypto Register-2 XORed with the right half of the Key Register goes to Crypto Register-2
 	for index := range cryptoReg2 {
-		cryptoReg2[index] = cryptoReg2[index] ^ keyBytes[index+8]
+		cryptoReg2[index] = cryptoReg2[index] ^ rightKey[index]
 	}
 
 	// See https://github.com/Abirdcfly/dupword/issues/26 for a fix to needing nolint
 	//nolint:dupword
 	// 4) XOR the Key Register with hexadecimal C0C0 C0C0 0000 0000 C0C0 C0C0 0000 0000
 	serializeKeyWithHexadecimal(keyBytes)
+	// Re-slice after the key register XOR (left half may have changed).
+	leftKey = keyBytes[:des.BlockSize]
+	rightKey = keyBytes[des.BlockSize:keyLen]
 
 	// 5) Crypto Register-1 XORed with the right half of the Key Register goes to Crypto Register-1
 	for index := range cryptoReg1 {
-		cryptoReg1[index] = cryptoReg1[index] ^ keyBytes[index+keyLen/2]
+		cryptoReg1[index] = cryptoReg1[index] ^ rightKey[index]
 	}
 
 	// 6) Crypto Register-1 DEA-encrypted using, as the key, the left half of the Key Register goes to Crypto Register-1
-	cipher2, _ := encryption.NewDesECB(keyBytes[:des.BlockSize])
+	cipher2, _ := encryption.NewDesECB(leftKey)
 	cryptoReg1, err = cipher2.Encrypt(cryptoReg1)
 	if err != nil {
 		return nil, err
@@ -100,7 +114,7 @@ func makeNonReversibleKey(ksnBytes, keyBytes []byte) ([]byte, error) {
 
 	// 7) Crypto Register-1 XORed with the right half of the Key Register goes to Crypto Register-1
 	for index := range cryptoReg1 {
-		cryptoReg1[index] = cryptoReg1[index] ^ keyBytes[index+keyLen/2]
+		cryptoReg1[index] = cryptoReg1[index] ^ rightKey[index]
 	}
 
 	return append(cryptoReg1, cryptoReg2...), nil

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -123,11 +123,12 @@ func GenerateNextDesKsn(ksn []byte) ([]byte, error) {
 
 	{
 		// tc is masked to 21 bits above; pack those bits into the trailing KSN bytes.
+		// Explicit & masks keep conversions within byte range for static analysis (gosec G115).
 		length := len(ksn)
-		ksn[length-1] = byte(tc & 0xFF)        //nolint:gosec // G115: low 8 bits of 21-bit counter
-		ksn[length-2] = byte((tc >> 8) & 0xFF) //nolint:gosec // G115: mid 8 bits of 21-bit counter
+		ksn[length-1] = byte(tc & 0xFF)
+		ksn[length-2] = byte((tc >> 8) & 0xFF)
 		ksn[length-3] &= 0xE0
-		ksn[length-3] |= byte((tc >> 16) & 0x1F) //nolint:gosec // G115: high 5 bits of 21-bit counter
+		ksn[length-3] |= byte((tc >> 16) & 0x1F)
 	}
 
 	return ksn, nil

--- a/pkg/util.go
+++ b/pkg/util.go
@@ -122,11 +122,12 @@ func GenerateNextDesKsn(ksn []byte) ([]byte, error) {
 	}
 
 	{
+		// tc is masked to 21 bits above; pack those bits into the trailing KSN bytes.
 		length := len(ksn)
-		ksn[length-1] = byte(tc)
-		ksn[length-2] = byte(tc >> 8)
+		ksn[length-1] = byte(tc & 0xFF)        //nolint:gosec // G115: low 8 bits of 21-bit counter
+		ksn[length-2] = byte((tc >> 8) & 0xFF) //nolint:gosec // G115: mid 8 bits of 21-bit counter
 		ksn[length-3] &= 0xE0
-		ksn[length-3] |= byte(tc >> 16)
+		ksn[length-3] |= byte((tc >> 16) & 0x1F) //nolint:gosec // G115: high 5 bits of 21-bit counter
 	}
 
 	return ksn, nil


### PR DESCRIPTION
## Summary
Silence CodeQL `go/weak-cryptographic-algorithm` warnings for intentional DES/3DES usage.

DUKPT (ANSI X9.24) requires TDEA/DES for legacy key derivation and data encryption. These algorithms cannot be removed without breaking the standard. This change adds `// codeql[go/weak-cryptographic-algorithm]` suppressions at:

- `encryption/des_ecb.go` — DES/3DES constructors and Encrypt/Decrypt
- `pkg/des/des.go` — CBC encrypt/decrypt paths

## Alerts addressed
- https://github.com/moov-io/dukpt/security/code-scanning/1
- https://github.com/moov-io/dukpt/security/code-scanning/2

## Test plan
- [x] `go test ./encryption/ ./pkg/des/`
- [ ] CI CodeQL Analysis on this PR